### PR TITLE
Add Object Caching (memcached) and Timeout Backoff

### DIFF
--- a/RSHighscores.body.php
+++ b/RSHighscores.body.php
@@ -84,10 +84,21 @@ class RSHiscores {
 
 		// Couldn't find in the object cache, so retrieve from the site.
 		if ( $data === false ) {
-			$data = self::retrieveHiscores( $hs, $player );
+			// If not blocked from too many requests or technical issues, then lookup.
+			if ( $objCache->get( 'rshiscores-blocked') === false ) {
+				$data = self::retrieveHiscores( $hs, $player );
 
-			// Cache the new results.
-			$objCache->set( 'rshiscores-' . $player . '-' . $hs, $data, 60 );
+				// Request failed, so no requests for 15 min.
+				if ( $data == 'C28' ) {
+					$objCache->set( 'rshiscores-blocked', true, 60 * 15 );
+				}
+
+				// Cache the new results.
+				$objCache->set( 'rshiscores-' . $player . '-' . $hs, $data, 60 );
+			} else {
+				// This or a previous request failed, so hold off further requests for now.
+				$data = 'I';
+			}
 		}
 
 		return $data;

--- a/RSHighscores.body.php
+++ b/RSHighscores.body.php
@@ -184,6 +184,12 @@ class RSHiscores {
 			// Add the hiscores data to the cache.
 			self::$cache[$hs][$player] = $data;
 
+			// If blocked, then cache for only 15 minutes.
+			if ( $data == 'I' ) {
+				$output = $parser->getOutput();
+				if ( $output->isCacheable() && $output->getCacheExpiry() > 60 * 15 )
+					$output->updateCacheExpiry( 60 * 15 );
+			}
 		} else {
 			// The name limit set by $wgRSLimit was reached.
 			return 'E';

--- a/RSHighscores.i18n.php
+++ b/RSHighscores.i18n.php
@@ -13,5 +13,6 @@ $messages = array();
  */
 $messages['en'] = array(
 	'rshiscores-desc' => 'Provides access to RuneScape\'s Hiscores data for use in wikitext and calculators.',
-	'rshiscores-error-category' => 'Pages with RSHiscores errors'
+	'rshiscores-error-category' => 'Pages with RSHiscores errors',
+	'rshiscores-error-category-desc' => 'The page contains broken usage of RSHiscores.'
 );

--- a/RSHighscores.php
+++ b/RSHighscores.php
@@ -33,6 +33,8 @@ $wgExtensionMessagesFiles['RSHiscoresMagic'] = __DIR__ . '/RSHighscores.i18n.mag
 
 $wgHooks['ParserFirstCallInit'][] = 'RSHiscores::register';
 
+$wgTrackingCategories[] = 'rshiscores-error-category';
+
 /**
  * Defines the maximum number of names allowed per page to retrieve hiscores
  * data for. This is not a call limit. This is to prevent abuse, especially


### PR DESCRIPTION
This pull request is mostly a proof of concept, proper design is to come. Generic object caching is implemented, which will use memcached when available. For now the cache time is set for one minute. When a timeout occurs new lookups are prevented for 15 minutes. I have modified the parser cache time in accord, though the specifics need adjusting. Planned too is to reduce the timeout, but that value is yet to be determined. I also have a commit for adding the error tracking category to Special:TrackingCategory, which I've left in because it's small.

Note: This is isn't ready to be pulled. I'm going to rebase it on #4 once that is pulled, after which I'll fix the localization and cache timeouts.
