### PR TITLE
Add memcached support to hiscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,15 @@ If an error occurs, then an error code will be returned. See [Errors](#errors) f
 ## Errors
 If there is an error in the usage or request, one of the following codes will be returned instead.
 
-| Code | Error                                                                                                                                  |
-| ---- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| A    | No name was entered.                                                                                                                   |
-| B    | The player could not be found.                                                                                                         |
+| Code | Error                |
+| ---- | -------------------- |
+| A    | No name was entered. |
+| B    | The player could not be found. |
 | C<#> | A curl error occurred, if it's form of C<#>, check the number [here](http://curl.haxx.se/libcurl/c/libcurl-errors.html) for the cause. |
 | D<#> | An unexpected HTTP status was returned, check the number [here](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes) for the cause. |
-| E    | The name call limit was reached. This is by default 2 player names. This is not a limit on the number of function calls.               |
-| F    | The skill does not exist.                                                                                                              |
-| G    | The type does not exist.                                                                                                               |
-| H    | The API is unknown or unsupported.                                                                                                     |
+| E    | The name call limit was reached. This is by default 2 player names. This is not a limit on the number of function calls. |
+| F    | The skill does not exist. |
+| G    | The type does not exist. |
+| H    | The API is unknown or unsupported. |
+       | The type does not exist. |
+| I    | A timeout error occurred, normally caused by too many requests being submitted in too short a time. This causes all requests to be prevented for a cooldown period of 15 minutes, at which point requests can be resumed. |

--- a/RSHighscores.body.php
+++ b/RSHighscores.body.php
@@ -84,10 +84,21 @@ class RSHiscores {
 
 		// Couldn't find in the object cache, so retrieve from the site.
 		if ( $data === false ) {
-			$data = self::retrieveHiscores( $hs, $player );
+			// If not blocked from too many requests or technical issues, then lookup.
+			if ( $objCache->get( 'rshiscores-blocked') === false ) {
+				$data = self::retrieveHiscores( $hs, $player );
 
-			// Cache the new results.
-			$objCache->set( 'rshiscores-' . $player . '-' . $hs, $data, 60 );
+				// Request failed, so no requests for 15 min.
+				if ( $data == 'C28' ) {
+					$objCache->set( 'rshiscores-blocked', true, 60 * 15 );
+				}
+
+				// Cache the new results.
+				$objCache->set( 'rshiscores-' . $player . '-' . $hs, $data, 60 );
+			} else {
+				// This or a previous request failed, so hold off further requests for now.
+				$data = 'I';
+			}
 		}
 
 		return $data;

--- a/RSHighscores.body.php
+++ b/RSHighscores.body.php
@@ -184,6 +184,12 @@ class RSHiscores {
 			// Add the hiscores data to the cache.
 			self::$cache[$hs][$player] = $data;
 
+			// If blocked, then cache for only 15 minutes.
+			if ( $data == 'I' ) {
+				$output = $parser->getOutput();
+				if ( $output->isCacheable() && $output->getCacheExpiry() > 60 * 15 )
+					$output->updateCacheExpiry( 60 * 15 );
+			}
 		} else {
 			// The name limit set by $wgRSLimit was reached.
 			return 'E';

--- a/RSHighscores.body.php
+++ b/RSHighscores.body.php
@@ -4,7 +4,7 @@
  */
 
 class RSHiscores {
-	public static $ch = NULL;
+	public static $ch = null;
 	public static $cache = [];
 	public static $times = 0;
 
@@ -27,51 +27,58 @@ class RSHiscores {
 	 * @return string Raw hiscores data
 	 */
 	private static function retrieveHiscores( $hs, $player ) {
-		global $wgHTTPTimeout;
+		global $wgRSTimeout;
 
-		if ( $hs == 'rs3' ) {
+		if ( $hs === 'rs3' ) {
 			$url = 'http://services.runescape.com/m=hiscore/index_lite.ws?player=';
-		} elseif ( $hs == 'osrs' ) {
+		} elseif ( $hs === 'osrs' ) {
 			$url = 'http://services.runescape.com/m=hiscore_oldschool/index_lite.ws?player=';
 		} else {
-			// Unknown or unsupported hiscores API.
+			// unknown or unsupported hiscores API
 			return 'H';
 		}
 
-		// Setup the cURL handler if not previously initialised.
-		if ( self::$ch == NULL ) {
+		// setup the cURL handler if not previously initialised
+		if ( self::$ch === null ) {
 			self::$ch = curl_init();
-			curl_setopt( self::$ch, CURLOPT_TIMEOUT, $wgHTTPTimeout );
-			curl_setopt( self::$ch, CURLOPT_RETURNTRANSFER, TRUE );
+
+			curl_setopt( self::$ch, CURLOPT_TIMEOUT, $wgRSTimeout );
+			curl_setopt( self::$ch, CURLOPT_RETURNTRANSFER, true );
 		}
 
-		curl_setopt( self::$ch, CURLOPT_URL, $url . urlencode( $player ) );
+		$url .= urlencode( $player );
+		curl_setopt( self::$ch, CURLOPT_URL, $url );
 
-		if ( $data = curl_exec( self::$ch ) ) {
+		$data = curl_exec( self::$ch );
+
+		if ( $data ) {
 			$status = curl_getinfo( self::$ch, CURLINFO_HTTP_CODE );
 
-			if ( $status == 200 ) {
+			if ( $status === 200 ) {
 				return $data;
 			}
 
-			if ( $status == 404 ) {
-				// The player could not be found.
+			if ( $status === 404 ) {
+				// the player could not be found
 				return 'B';
 			}
 
-			// An unexpected HTTP status code was returned, so report it.
+			// unexpected HTTP status code
 			return 'D' . $status;
 		}
 
-		// An unexpected curl error occurred, so report it.
+		// unexpected curl error occurred
+		$ret = 'C';
 		$errno = curl_errno( self::$ch );
 
-		if( $errno ) {
-			return 'C' . $errno;
+		// should be impossible for this to fail
+		// but just in case
+		if ( $errno ) {
+			$ret .= $errno;
 		}
 
-		// Should be impossible, but odd things happen, so handle it.
-		return 'C';
+
+		return $ret;
 	}
 
 	/**
@@ -84,26 +91,28 @@ class RSHiscores {
 	private static function lookupHiscores( $hs, $player ) {
 		global $wgMemc;
 
-		// Try to retrieve the hiscores data from the object cache.
-		$data = $wgMemc->get( 'rshiscores-' . $player . '-' . $hs );
+		$key = wfMemcKey( 'rshiscores', $player, $hs );
+		$blockedKey = wfMemcKey( 'rshiscores-blocked' );
 
-		// Couldn't find in the object cache, so retrieve from the site.
+		$data = $wgMemc->get( $resKey );
+
+		// couldn't find in the cache, so get it from the API
 		if ( $data === false ) {
-			// If not blocked from too many requests or technical issues, then lookup.
-			if ( $wgMemc->get( 'rshiscores-blocked') === false ) {
+			// check to see if we've had a blocked request recently before trying
+			if ( $wgMemc->get( $blockedKey ) === false ) {
 				$data = self::retrieveHiscores( $hs, $player );
 
-				// Request failed, so no requests for 15 min.
-				if ( $data == 'C28' ) {
-					$blockedKey = wfMemcKey( 'rshiscores-blocked' );
+				// request failed, so no requests for 15 min
+				if ( $data === 'C28' ) {
 					$wgMemc->set( $blockedKey, true, 60 * 15 );
+
+					// convert to a more descriptive message
+					$data = 'I';
 				}
 
-				// Cache the new results.
-				$resKey = wfMemcKey( 'rshiscores', $player, $hs );
-				$wgMemc->set( $resKey, $data, 60 );
+				$wgMemc->set( $key, $data, 60 );
 			} else {
-				// This or a previous request failed, so hold off further requests for now.
+				// previous request failed
 				$data = 'I';
 			}
 		}
@@ -120,24 +129,23 @@ class RSHiscores {
 	 * @return string Requested portion of the hiscores data.
 	 */
 	private static function parseHiscores( $data, $skill, $type ) {
-		// Check to see if an error has already occurred.
-		// If so, return the error now, otherwise the wrong error will be
-		// returned. Some errors have int statuses, so only check first char.
+		// check to see if an error has already occurred and return it if so
+		// some errors have int statuses, so only check first char
 		if ( ctype_alpha( $data{0} ) ) {
 			return $data;
 		}
 
-		$data = explode( "\n", $data, $skill + 2 );
+		$data = explode( '\n', $data, $skill + 2 );
 
 		if ( !array_key_exists( $skill, $data ) ) {
-			// The skill does not exist.
+			// skill does not exist.
 			return 'F';
 		}
 
 		$data = explode( ',', $data[$skill], $type + 2 );
 
 		if ( !array_key_exists( $type, $data ) ) {
-			// The type does not exist.
+			// type does not exist.
 			return 'G';
 		}
 
@@ -150,21 +158,21 @@ class RSHiscores {
 	 * @param string $hs Which hiscores API to use.
 	 * @param string $player Player's display name. Can not be empty.
 	 * @param int $skill Index representing the requested skill. Leave as -1 for requesting the
-	 *                   raw data.
+	 *     raw data.
 	 * @param int $type Index representing the requested type of data for the given skill.
 	 * @return string
 	 */
 	private static function getHiscores( $hs, $player, $skill, $type ) {
 		global $wgRSLimit;
 
-		if ( $hs != 'rs3' && $hs != 'osrs' ) {
+		if ( $hs !== 'rs3' && $hs !== 'osrs' ) {
 			// Unknown or unsupported hiscores API.
 			return 'H';
 		}
 
 		$player = trim( $player );
 
-		if( $player == '' ) {
+		if( $player === '' ) {
 			// No name was entered.
 			return 'A';
 
@@ -174,7 +182,7 @@ class RSHiscores {
 			// Get the hiscores data from the cache.
 			$data = self::$cache[$hs][$player];
 
-		} elseif ( self::$times < $wgRSLimit || $wgRSLimit == 0 ) {
+		} elseif ( self::$times < $wgRSLimit || $wgRSLimit === 0 ) {
 			// Update the name limit counter.
 			self::$times++;
 
@@ -189,7 +197,7 @@ class RSHiscores {
 			self::$cache[$hs][$player] = $data;
 
 			// If blocked, then cache for only 15 minutes.
-			if ( $data == 'I' ) {
+			if ( $data === 'I' ) {
 				$output = $parser->getOutput();
 
 				if ( $output->isCacheable() && $output->getCacheExpiry() > 60 * 15 ) {
@@ -218,7 +226,7 @@ class RSHiscores {
 	 * @param string $hs Which hiscores API to use.
 	 * @param string $player Player's display name. Can not be empty.
 	 * @param int $skill Index representing the requested skill. Leave as -1 for requesting the
-	 *                   raw data.
+	 *     raw data.
 	 * @param int $type Index representing the requested type of data for the given skill.
 	 * @return string
 	 */
@@ -230,14 +238,14 @@ class RSHiscores {
 			$parser->addTrackingCategory( 'rshiscores-error-category' );
 			$msg = wfMessage( 'rshiscores-error-' . $first );
 
-			// Pass any error codes to the returned message as parameters.
+			// pass any error codes to the returned message as parameters
 			if ( strlen( $ret ) > 1 ) {
-				$msg = $msg->params( substr( $ret, 1 ) )->parse();
-			} else {
-				$msg = $msg->parse();
+				$msg = $msg->params( substr( $ret, 1 ) )
 			}
 
-			// Return an error format compatible with #iferror.
+			$msg = $msg->parse();
+
+			// return an error format compatible with #iferror
 			return '<span class="error">' . $msg . '</span>';
 		}
 

--- a/RSHighscores.i18n.php
+++ b/RSHighscores.i18n.php
@@ -13,5 +13,6 @@ $messages = array();
  */
 $messages['en'] = array(
 	'rshiscores-desc' => 'Provides access to RuneScape\'s Hiscores data for use in wikitext and calculators.',
-	'rshiscores-error-category' => 'Pages with RSHiscores errors'
+	'rshiscores-error-category' => 'Pages with RSHiscores errors',
+	'rshiscores-error-category-desc' => 'The page contains broken usage of RSHiscores.'
 );

--- a/RSHighscores.i18n.php
+++ b/RSHighscores.i18n.php
@@ -6,34 +6,37 @@
  * @ingroup Extensions
  */
 
-$messages = array();
+$messages = [];
 
-$messages['qqq'] = array(
-	'rshiscores-desc'		=> '{{desc}}',
-	'rshiscores-error-category'	=> 'Category for tagging errors returned by the parser function.',
-	'rshiscores-error-A'		=> 'Error message for missing player name.',
-	'rshiscores-error-B'		=> 'Error message for a player that was not found in the RuneScape Hiscores',
-	'rshiscores-error-C'		=> 'Error message for when a curl error occurs, where $1 is the number of the curl error.',
-	'rshiscores-error-D'		=> 'Error message for when a HTTP error occurs, where $1 is the HTTP status.',
-	'rshiscores-error-E'		=> 'Error message for when $wgRSLimit is exceeded.',
-	'rshiscores-error-F'		=> 'Error message for when the skill requested does not exist.',
-	'rshiscores-error-G'		=> 'Error message for when the type requested does not exist.',
-	'rshiscores-error-H'		=> 'Error message for when the API requested does not exist.'
-);
+$messages['qqq'] = [
+	'rshiscores-desc'			=> '{{desc}}',
+	'rshiscores-error-category'		=> 'Category for tagging errors returned by the parser function.',
+	'rshiscores-error-category-desc'	=> 'Description message for error category.',
+	'rshiscores-error-A'			=> 'Error message for missing player name.',
+	'rshiscores-error-B'			=> 'Error message for a player that was not found in the RuneScape Hiscores',
+	'rshiscores-error-C'			=> 'Error message for when a curl error occurs, where $1 is the number of the curl error.',
+	'rshiscores-error-D'			=> 'Error message for when a HTTP error occurs, where $1 is the HTTP status.',
+	'rshiscores-error-E'			=> 'Error message for when $wgRSLimit is exceeded.',
+	'rshiscores-error-F'			=> 'Error message for when the skill requested does not exist.',
+	'rshiscores-error-G'			=> 'Error message for when the type requested does not exist.',
+	'rshiscores-error-H'			=> 'Error message for when the API requested does not exist.',
+	'rshiscores-error-I'			=> 'Error message for when a tiemout error occurs and all requests are temporarily prevented for a cooldown period.'
+];
 
 /**
  * English (English)
  */
-$messages['en'] = array(
-	'rshiscores-desc' => 'Provides access to RuneScape\'s Hiscores data for use in wikitext and calculators.',
-	'rshiscores-error-category' => 'Pages with RSHiscores errors',
-	'rshiscores-error-category-desc' => 'The page contains broken usage of RSHiscores.'
-	'rshiscores-error-A'		=> 'Player name missing.',
-	'rshiscores-error-B'		=> 'Player was not found in RuneScape\'s Hiscores.',
-	'rshiscores-error-C'		=> 'Unexpected curl error returned: $1.',
-	'rshiscores-error-D'		=> 'Unexpected HTTP status returned: $1.',
-	'rshiscores-error-E'		=> 'Name call limit exceeded.',
-	'rshiscores-error-F'		=> 'The skill requested does not exist.',
-	'rshiscores-error-G'		=> 'The type requested does not exist.',
-	'rshiscores-error-H'		=> 'Unexpected API type entered.'
-);
+$messages['en'] = [
+	'rshiscores-desc'			=> 'Provides access to RuneScape\'s Hiscores data for use in wikitext and calculators.',
+	'rshiscores-error-category'		=> 'Pages with RSHiscores errors',
+	'rshiscores-error-category-desc'	=> 'The page contains broken usage of RSHiscores.'
+	'rshiscores-error-A'			=> 'Player name missing.',
+	'rshiscores-error-B'			=> 'Player was not found in RuneScape\'s Hiscores.',
+	'rshiscores-error-C'			=> 'Unexpected curl error returned: $1.',
+	'rshiscores-error-D'			=> 'Unexpected HTTP status returned: $1.',
+	'rshiscores-error-E'			=> 'Name call limit exceeded.',
+	'rshiscores-error-F'			=> 'The skill requested does not exist.',
+	'rshiscores-error-G'			=> 'The type requested does not exist.',
+	'rshiscores-error-H'			=> 'Unexpected API type entered.',
+	'rshiscores-error-I'			=> 'Timeout error returned. All requests are temporarily prevented.'
+];

--- a/RSHighscores.php
+++ b/RSHighscores.php
@@ -33,6 +33,8 @@ $wgExtensionMessagesFiles['RSHiscoresMagic'] = __DIR__ . '/RSHighscores.i18n.mag
 
 $wgHooks['ParserFirstCallInit'][] = 'RSHiscores::register';
 
+$wgTrackingCategories[] = 'rshiscores-error-category';
+
 /**
  * Defines the maximum number of names allowed per page to retrieve hiscores
  * data for. This is not a call limit. This is to prevent abuse, especially

--- a/RSHighscores.php
+++ b/RSHighscores.php
@@ -17,18 +17,18 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die();
 }
 
-$wgExtensionCredits['parserhook'][] = array(
+$wgExtensionCredits['parserhook'][] = [
 	'path'			=> __FILE__,
 	'name'			=> 'RSHiscores',
 	'version'		=> '3.1.0',
 	'descriptionmsg'	=> 'rshiscores-desc',
 	'url'			=> 'https://github.com/rswiki/RSHiscores',
-	'author'		=> array(
+	'author'		=> [
 		'[http://runescape.wikia.com/wiki/User_talk:TehKittyCat TehKittyCat]',
 		'[http://runescape.wikia.com/wiki/User:Quarenon Quarenon]',
 		'[http://runescape.wikia.com/wiki/User:Cqm Cqm]',
-	),
-);
+	],
+];
 
 $wgAutoloadClasses['RSHiscores'] = __DIR__ . '/RSHighscores.body.php';
 
@@ -46,3 +46,8 @@ $wgTrackingCategories[] = 'rshiscores-error-category';
  * comparisons. Set to 0 to disable this limit. On Wikia the limit is set to 2.
  */
 $wgRSLimit = 2;
+
+/**
+ * Defines the amount of time in seonds allowed for each lookup before timing out.
+ */
+$wgRSTimeout = 5;


### PR DESCRIPTION
Various improvements, mostly imported from #5:
- Add a flag for when a timeout error has occurred and prevent all requests for a cooldown period of 15 minutes to prevent being blacklisted.
- Cache successful requests to improve performance when requests are executed en masse (caused by message cache being rebuilt or a high use template being altered).
- Add tracking category for usages that returned an error.
- Minor code cleanup.
